### PR TITLE
Update README.rst to specify typing imports with beartype.typing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3234,6 +3234,14 @@ to destroy everything you hold dear (in ascending order of justice):
 
       # ...instead of this.
       #from typing import Dict, FrozenSet, List, Set, Tuple, Type
+      
+      # Note, basic python: `from beartype import typing`
+      # doesn't let you `from typing import ...` from prior import!
+      from beartype import typing
+      from typing import __file__ as fname; print(fname)
+      # Ex: .../python3.8/typing.py 😞
+      from beartype.typing import __file__ as fname; print(fname)
+      # Ex: .../site-packages/beartype/typing/__init__.py 😎
 
    The public ``beartype.typing`` API is a mypy_-compliant replacement for
    the typing_ API offering improved forward compatibility with future Python


### PR DESCRIPTION
This should probably be done first as an issue, but since the question ask is a documentation change, I've included it in the PR. Specifically, the change also specifies the problem: if your python-fu is a wee bit lacking, you might've been doing
```
from beartype import typing
from typing import ...
``` 
All this time, and it just so happened to work, until it didn't.  If there's a better place for this, or not at all, this commit / PR can just be deleted.